### PR TITLE
Join on path with None component is okay

### DIFF
--- a/cloudsync_gdrive.py
+++ b/cloudsync_gdrive.py
@@ -774,10 +774,9 @@ class GDriveProvider(Provider):  # pylint: disable=too-many-public-methods, too-
 
         if info and info.pids and info.name:
             ppath = self._path_oid(info.pids[0])
-            if ppath:
-                path = self.join(ppath, info.name)
-                self._ids[path] = oid
-                return path
+            path = self.join(ppath, info.name)
+            self._ids[path] = oid
+            return path
         return None
 
     def info_oid(self, oid: str, use_cache=True) -> Optional[GDriveInfo]:


### PR DESCRIPTION
If you try to call path_oid with an empty _ids cache, the result will always be None. Joining with None as the first component is entirely legal, and in this case exactly what we want. None represents the root for the provider, so we should not be afraid to call join with it as the first parameter.