### PR TITLE
Use root oid property

### DIFF
--- a/cloudsync_gdrive.py
+++ b/cloudsync_gdrive.py
@@ -31,7 +31,7 @@ from cloudsync.oauth import OAuthConfig, OAuthError, OAuthProviderInfo
 CACHE_QUOTA_TIME = 120
 
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 
 
 class GDriveFileDoneError(Exception):

--- a/cloudsync_gdrive.py
+++ b/cloudsync_gdrive.py
@@ -774,10 +774,9 @@ class GDriveProvider(Provider):  # pylint: disable=too-many-public-methods, too-
 
         if info and info.pids and info.name:
             ppath = self._path_oid(info.pids[0])
-            if ppath:
-                path = self.join(ppath, info.name)
-                self._ids[path] = oid
-                return path
+            path = self.join(ppath, info.name)
+            self._ids[path] = oid
+            return path
         return None
 
     def info_oid(self, oid: str, use_cache=True) -> Optional[GDriveInfo]:

--- a/cloudsync_gdrive.py
+++ b/cloudsync_gdrive.py
@@ -633,7 +633,7 @@ class GDriveProvider(Provider):  # pylint: disable=too-many-public-methods, too-
                 raise CloudFileExistsError("Cannot delete non-empty folder %s:%s" % (oid, info.name))
             except StopIteration:
                 pass  # Folder is empty, delete it no problem
-        if oid == self.__root_id:
+        if oid == self._root_id:
             raise CloudFileExistsError("Cannot delete root folder")
         try:
             self._api('files', 'delete', fileId=oid)
@@ -764,7 +764,7 @@ class GDriveProvider(Provider):  # pylint: disable=too-many-public-methods, too-
                 if pid == oid:
                     return p
 
-        if oid == self.__root_id:
+        if oid == self._root_id:
             return "/"
 
         # todo, better cache, keep up to date, etc.
@@ -774,9 +774,10 @@ class GDriveProvider(Provider):  # pylint: disable=too-many-public-methods, too-
 
         if info and info.pids and info.name:
             ppath = self._path_oid(info.pids[0])
-            path = self.join(ppath, info.name)
-            self._ids[path] = oid
-            return path
+            if ppath:
+                path = self.join(ppath, info.name)
+                self._ids[path] = oid
+                return path
         return None
 
     def info_oid(self, oid: str, use_cache=True) -> Optional[GDriveInfo]:


### PR DESCRIPTION
In two instances we were looking at the cached value for the root oid instead of calling the property