### PR TITLE
Fix clousync tests when the root changes

### DIFF
--- a/cloudsync_gdrive.py
+++ b/cloudsync_gdrive.py
@@ -800,9 +800,6 @@ class GDriveProvider(Provider):  # pylint: disable=too-many-public-methods, too-
         return md5.hexdigest()
 
     def _info_oid(self, oid) -> Optional[GDriveInfo]:
-        if oid is None:
-            return None
-
         try:
             res = self._api('files', 'get', fileId=oid,
                             fields='name, md5Checksum, parents, mimeType, trashed, shared, capabilities, size',


### PR DESCRIPTION
If the root oid changes, we need to hit the gdrive api to update the local reference