### PR TITLE
BI-2 986: Mark exists=False for trashed items 

### DIFF
--- a/cloudsync_gdrive.py
+++ b/cloudsync_gdrive.py
@@ -31,7 +31,7 @@ from cloudsync.oauth import OAuthConfig, OAuthError, OAuthProviderInfo
 CACHE_QUOTA_TIME = 120
 
 
-__version__ = "1.0.5"
+__version__ = "1.0.6"
 
 
 class GDriveFileDoneError(Exception):

--- a/cloudsync_gdrive.py
+++ b/cloudsync_gdrive.py
@@ -3,7 +3,6 @@ Provider "gdrive", exports GDriveProvider
 """
 # pylint: disable=missing-docstring
 
-import enum
 import io
 import time
 import logging
@@ -43,19 +42,6 @@ log = logging.getLogger(__name__)
 logging.getLogger('googleapiclient').setLevel(logging.INFO)
 logging.getLogger('googleapiclient.discovery').setLevel(logging.ERROR)
 
-class EventFilter(enum.Enum):
-    """
-    Event filter result
-    """
-    PROCESS = "process"
-    IGNORE = "ignore"
-    WALK = "walk"
-
-    def __bool__(self):
-        """
-        Protect against bool use
-        """
-        raise ValueError("never bool enums")
 
 class GDriveInfo(DirInfo):  # pylint: disable=too-few-public-methods
     pids: List[str] = []
@@ -326,103 +312,59 @@ class GDriveProvider(Provider):  # pylint: disable=too-many-public-methods, too-
             new_cursor = response.get('newStartPageToken', None)
             for change in response.get('changes'):
                 log.debug("got event %s", change)
-                event = self._convert_to_event(change, new_cursor)
+
+                # {'kind': 'drive#change', 'type': 'file', 'changeType': 'file', 'time': '2019-07-23T16:57:06.779Z',
+                # 'removed': False, 'fileId': '1NCi2j1SjsPUTQTtaD2dFNsrt49J8TPDd', 'file': {'kind': 'drive#file',
+                # 'id': '1NCi2j1SjsPUTQTtaD2dFNsrt49J8TPDd', 'name': 'dest', 'mimeType': 'application/octet-stream'}}
+
+                # {'kind': 'drive#change', 'type': 'file', 'changeType': 'file', 'time': '2019-07-23T20:02:14.156Z',
+                # 'removed': True, 'fileId': '1lhRe0nDplA6I5JS18642rg0KIbYN66lR'}
+
+                ts = arrow.get(change.get('time')).float_timestamp
+                oid = change.get('fileId')
+                exists = None
+                if 'removed' in change.keys():
+                    exists = not change.get('removed')
+
+                fil = change.get('file')
+                if fil:
+                    if fil.get('mimeType') == self._folder_mime_type:
+                        otype = DIRECTORY
+                    else:
+                        otype = FILE
+                else:
+                    otype = NOTKNOWN
+
+                ohash = None
+                path = self._path_oid(oid, use_cache=False)
+                if not path:
+                    # Trashed
+                    exists = False
+
+                event = Event(otype, oid, path, ohash, exists, ts, new_cursor=new_cursor)
+
+                remove = []
+                for cpath, coid in self._ids.items():
+                    if coid == oid:
+                        if cpath != path:
+                            remove.append(cpath)  # remove the event's item if it's path changed
+
+                    if path and otype == DIRECTORY and self.is_subpath(path, cpath):
+                        remove.append(cpath)  # if the event's item is a folder, uncache its children
+
+                for r in remove:
+                    self._ids.pop(r, None)
+
+                if path:
+                    self._ids[path] = oid
+
                 log.debug("converted event %s as %s", change, event)
-                filter_result = self._filter_event(event)
-                if filter_result == EventFilter.IGNORE:
-                    if event:
-                        log.debug("ignore event: %s %s %s", event.path, event.oid, event.exists)
-                    continue
-                if filter_result == EventFilter.WALK:
-                    log.debug("directory created in or renamed into root - walking: %s", event.path)
-                    try:
-                        yield from self.walk_oid(event.oid)
-                    except CloudFileNotFoundError:
-                        pass
+
                 yield event
 
             if new_cursor and page_token and new_cursor != page_token:
                 self.__cursor = new_cursor
             page_token = response.get('nextPageToken')
-
-    def _convert_to_event(self, change, new_cursor):
-        ts = arrow.get(change.get('time')).float_timestamp
-        oid = change.get('fileId')
-        exists = None
-        if 'removed' in change.keys():
-            exists = not change.get('removed')
-
-        fil = change.get('file')
-        if fil:
-            if fil.get('mimeType') == self._folder_mime_type:
-                otype = DIRECTORY
-            else:
-                otype = FILE
-        else:
-            otype = NOTKNOWN
-
-        ohash = None
-        path = self._path_oid(oid, use_cache=False)
-        if not path:
-            # Trashed
-            exists = False
-
-        event = Event(otype, oid, path, ohash, exists, ts, new_cursor=new_cursor)
-
-        remove = []
-        for cpath, coid in self._ids.items():
-            if coid == oid:
-                if cpath != path:
-                    remove.append(cpath)  # remove the event's item if it's path changed
-
-            if path and otype == DIRECTORY and self.is_subpath(path, cpath):
-                remove.append(cpath)  # if the event's item is a folder, uncache its children
-
-        for r in remove:
-            self._ids.pop(r, None)
-
-        if path:
-            self._ids[path] = oid
-
-        return event
-
-    def _filter_event(self, event):
-        # event filtering based on root path and event path
-
-        if not event:
-            return EventFilter.IGNORE
-
-        if not self._root_path:
-            return EventFilter.PROCESS
-
-        state_path = self.sync_state.get_path(event.oid)
-        prior_subpath = self.is_subpath_of_root(state_path)
-        if not event.exists:
-            # delete - ignore if not in state, or in state but is not subpath of root
-            return EventFilter.PROCESS if prior_subpath else EventFilter.IGNORE
-
-        if event.path:
-            curr_subpath = self.is_subpath_of_root(event.path)
-            if curr_subpath and not prior_subpath:
-                # Can't differentiate between creates and renames without watching the entire filesystem:
-                # Event has an oid and a current path, its a rename if the oid was seen before,
-                # but since events outside root are ignored we don't catch the case where an item is
-                # created outside root and then renamed into root.
-                # Hence the walk for directories -- a tradeoff for ignoring "outside root" events.
-                log.debug("created in or renamed into root: %s", event.path)
-                if event.otype == DIRECTORY:
-                    return EventFilter.WALK
-            elif prior_subpath and not curr_subpath:
-                # Rename out of root: process the event.
-                # Treated as a delete by the sync engine, which handles non-empty folders by marking
-                # children "changed" and processing them first.
-                log.debug("renamed out of root: %s", event.path)
-            else:
-                # both curr and prior are subpaths == rename within root (process event)
-                # neither is subpath == rename outside root (ignore event)
-                return EventFilter.PROCESS if curr_subpath else EventFilter.IGNORE
-
-        return EventFilter.PROCESS
 
     def _prep_upload(self, path, metadata):
         # modification time

--- a/cloudsync_gdrive.py
+++ b/cloudsync_gdrive.py
@@ -349,9 +349,9 @@ class GDriveProvider(Provider):  # pylint: disable=too-many-public-methods, too-
     def _convert_to_event(self, change, new_cursor):
         ts = arrow.get(change.get('time')).float_timestamp
         oid = change.get('fileId')
+        # File is removed: exists is False. Else: the file may be trashed, mark exists as None
         exists = None
         if change.get('removed') is True:
-            # Can't necessarily mark exists as true, could be trashed
             exists = False
 
         fil = change.get('file')

--- a/cloudsync_gdrive.py
+++ b/cloudsync_gdrive.py
@@ -3,7 +3,6 @@ Provider "gdrive", exports GDriveProvider
 """
 # pylint: disable=missing-docstring
 
-import enum
 import io
 import time
 import logging
@@ -43,19 +42,6 @@ log = logging.getLogger(__name__)
 logging.getLogger('googleapiclient').setLevel(logging.INFO)
 logging.getLogger('googleapiclient.discovery').setLevel(logging.ERROR)
 
-class EventFilter(enum.Enum):
-    """
-    Event filter result
-    """
-    PROCESS = "process"
-    IGNORE = "ignore"
-    WALK = "walk"
-
-    def __bool__(self):
-        """
-        Protect against bool use
-        """
-        raise ValueError("never bool enums")
 
 class GDriveInfo(DirInfo):  # pylint: disable=too-few-public-methods
     pids: List[str] = []
@@ -329,17 +315,6 @@ class GDriveProvider(Provider):  # pylint: disable=too-many-public-methods, too-
                 log.debug("got event %s", change)
                 event = self._convert_to_event(change, new_cursor)
                 log.debug("converted event %s as %s", change, event)
-                filter_result = self._filter_event(event)
-                if filter_result == EventFilter.IGNORE:
-                    if event:
-                        log.debug("ignore event: %s %s %s", event.path, event.oid, event.exists)
-                    continue
-                if filter_result == EventFilter.WALK:
-                    log.debug("directory created in or renamed into root - walking: %s", event.path)
-                    try:
-                        yield from self.walk_oid(event.oid)
-                    except CloudFileNotFoundError:
-                        pass
                 yield event
 
             if new_cursor and page_token and new_cursor != page_token:
@@ -384,44 +359,6 @@ class GDriveProvider(Provider):  # pylint: disable=too-many-public-methods, too-
             self._ids[path] = oid
 
         return event
-
-    def _filter_event(self, event):
-        # event filtering based on root path and event path
-
-        if not event:
-            return EventFilter.IGNORE
-
-        if not self._root_path:
-            return EventFilter.PROCESS
-
-        state_path = self.sync_state.get_path(event.oid)
-        prior_subpath = self.is_subpath_of_root(state_path)
-        if not event.exists:
-            # delete - ignore if not in state, or in state but is not subpath of root
-            return EventFilter.PROCESS if prior_subpath else EventFilter.IGNORE
-
-        if event.path:
-            curr_subpath = self.is_subpath_of_root(event.path)
-            if curr_subpath and not prior_subpath:
-                # Can't differentiate between creates and renames without watching the entire filesystem:
-                # Event has an oid and a current path, its a rename if the oid was seen before,
-                # but since events outside root are ignored we don't catch the case where an item is
-                # created outside root and then renamed into root.
-                # Hence the walk for directories -- a tradeoff for ignoring "outside root" events.
-                log.debug("created in or renamed into root: %s", event.path)
-                if event.otype == DIRECTORY:
-                    return EventFilter.WALK
-            elif prior_subpath and not curr_subpath:
-                # Rename out of root: process the event.
-                # Treated as a delete by the sync engine, which handles non-empty folders by marking
-                # children "changed" and processing them first.
-                log.debug("renamed out of root: %s", event.path)
-            else:
-                # both curr and prior are subpaths == rename within root (process event)
-                # neither is subpath == rename outside root (ignore event)
-                return EventFilter.PROCESS if curr_subpath else EventFilter.IGNORE
-
-        return EventFilter.PROCESS
 
     def _prep_upload(self, path, metadata):
         # modification time

--- a/cloudsync_gdrive.py
+++ b/cloudsync_gdrive.py
@@ -323,8 +323,9 @@ class GDriveProvider(Provider):  # pylint: disable=too-many-public-methods, too-
                 ts = arrow.get(change.get('time')).float_timestamp
                 oid = change.get('fileId')
                 exists = None
-                if 'removed' in change.keys():
-                    exists = not change.get('removed')
+                if change.get('removed') is True:
+                    # Can't necessarily mark exists as true, could be trashed
+                    exists = False
 
                 fil = change.get('file')
                 if fil:
@@ -336,10 +337,7 @@ class GDriveProvider(Provider):  # pylint: disable=too-many-public-methods, too-
                     otype = NOTKNOWN
 
                 ohash = None
-                path = self._path_oid(oid, use_cache=False)
-                if not path:
-                    # Trashed
-                    exists = False
+                path = None
 
                 event = Event(otype, oid, path, ohash, exists, ts, new_cursor=new_cursor)
 

--- a/cloudsync_gdrive.py
+++ b/cloudsync_gdrive.py
@@ -535,7 +535,6 @@ class GDriveProvider(Provider):  # pylint: disable=too-many-public-methods, too-
                     except StopIteration:
                         # Folder is empty, rename over it no problem
                         if possible_conflict.oid != oid:  # delete the target if we're not just changing case
-                            log.debug("REED_DEBUG, rename conflict, conflict_oid=%s, oid=%s", possible_conflict.oid, oid) 
                             self.delete(possible_conflict.oid)
 
         if not old_path:

--- a/cloudsync_gdrive.py
+++ b/cloudsync_gdrive.py
@@ -3,6 +3,7 @@ Provider "gdrive", exports GDriveProvider
 """
 # pylint: disable=missing-docstring
 
+import enum
 import io
 import time
 import logging
@@ -42,6 +43,19 @@ log = logging.getLogger(__name__)
 logging.getLogger('googleapiclient').setLevel(logging.INFO)
 logging.getLogger('googleapiclient.discovery').setLevel(logging.ERROR)
 
+class EventFilter(enum.Enum):
+    """
+    Event filter result
+    """
+    PROCESS = "process"
+    IGNORE = "ignore"
+    WALK = "walk"
+
+    def __bool__(self):
+        """
+        Protect against bool use
+        """
+        raise ValueError("never bool enums")
 
 class GDriveInfo(DirInfo):  # pylint: disable=too-few-public-methods
     pids: List[str] = []
@@ -312,59 +326,103 @@ class GDriveProvider(Provider):  # pylint: disable=too-many-public-methods, too-
             new_cursor = response.get('newStartPageToken', None)
             for change in response.get('changes'):
                 log.debug("got event %s", change)
-
-                # {'kind': 'drive#change', 'type': 'file', 'changeType': 'file', 'time': '2019-07-23T16:57:06.779Z',
-                # 'removed': False, 'fileId': '1NCi2j1SjsPUTQTtaD2dFNsrt49J8TPDd', 'file': {'kind': 'drive#file',
-                # 'id': '1NCi2j1SjsPUTQTtaD2dFNsrt49J8TPDd', 'name': 'dest', 'mimeType': 'application/octet-stream'}}
-
-                # {'kind': 'drive#change', 'type': 'file', 'changeType': 'file', 'time': '2019-07-23T20:02:14.156Z',
-                # 'removed': True, 'fileId': '1lhRe0nDplA6I5JS18642rg0KIbYN66lR'}
-
-                ts = arrow.get(change.get('time')).float_timestamp
-                oid = change.get('fileId')
-                exists = None
-                if 'removed' in change.keys():
-                    exists = not change.get('removed')
-
-                fil = change.get('file')
-                if fil:
-                    if fil.get('mimeType') == self._folder_mime_type:
-                        otype = DIRECTORY
-                    else:
-                        otype = FILE
-                else:
-                    otype = NOTKNOWN
-
-                ohash = None
-                path = self._path_oid(oid, use_cache=False)
-                if not path:
-                    # Trashed
-                    exists = False
-
-                event = Event(otype, oid, path, ohash, exists, ts, new_cursor=new_cursor)
-
-                remove = []
-                for cpath, coid in self._ids.items():
-                    if coid == oid:
-                        if cpath != path:
-                            remove.append(cpath)  # remove the event's item if it's path changed
-
-                    if path and otype == DIRECTORY and self.is_subpath(path, cpath):
-                        remove.append(cpath)  # if the event's item is a folder, uncache its children
-
-                for r in remove:
-                    self._ids.pop(r, None)
-
-                if path:
-                    self._ids[path] = oid
-
+                event = self._convert_to_event(change, new_cursor)
                 log.debug("converted event %s as %s", change, event)
-
+                filter_result = self._filter_event(event)
+                if filter_result == EventFilter.IGNORE:
+                    if event:
+                        log.debug("ignore event: %s %s %s", event.path, event.oid, event.exists)
+                    continue
+                if filter_result == EventFilter.WALK:
+                    log.debug("directory created in or renamed into root - walking: %s", event.path)
+                    try:
+                        yield from self.walk_oid(event.oid)
+                    except CloudFileNotFoundError:
+                        pass
                 yield event
 
             if new_cursor and page_token and new_cursor != page_token:
                 self.__cursor = new_cursor
             page_token = response.get('nextPageToken')
+
+    def _convert_to_event(self, change, new_cursor):
+        ts = arrow.get(change.get('time')).float_timestamp
+        oid = change.get('fileId')
+        exists = None
+        if 'removed' in change.keys():
+            exists = not change.get('removed')
+
+        fil = change.get('file')
+        if fil:
+            if fil.get('mimeType') == self._folder_mime_type:
+                otype = DIRECTORY
+            else:
+                otype = FILE
+        else:
+            otype = NOTKNOWN
+
+        ohash = None
+        path = self._path_oid(oid, use_cache=False)
+        if not path:
+            # Trashed
+            exists = False
+
+        event = Event(otype, oid, path, ohash, exists, ts, new_cursor=new_cursor)
+
+        remove = []
+        for cpath, coid in self._ids.items():
+            if coid == oid:
+                if cpath != path:
+                    remove.append(cpath)  # remove the event's item if it's path changed
+
+            if path and otype == DIRECTORY and self.is_subpath(path, cpath):
+                remove.append(cpath)  # if the event's item is a folder, uncache its children
+
+        for r in remove:
+            self._ids.pop(r, None)
+
+        if path:
+            self._ids[path] = oid
+
+        return event
+
+    def _filter_event(self, event):
+        # event filtering based on root path and event path
+
+        if not event:
+            return EventFilter.IGNORE
+
+        if not self._root_path:
+            return EventFilter.PROCESS
+
+        state_path = self.sync_state.get_path(event.oid)
+        prior_subpath = self.is_subpath_of_root(state_path)
+        if not event.exists:
+            # delete - ignore if not in state, or in state but is not subpath of root
+            return EventFilter.PROCESS if prior_subpath else EventFilter.IGNORE
+
+        if event.path:
+            curr_subpath = self.is_subpath_of_root(event.path)
+            if curr_subpath and not prior_subpath:
+                # Can't differentiate between creates and renames without watching the entire filesystem:
+                # Event has an oid and a current path, its a rename if the oid was seen before,
+                # but since events outside root are ignored we don't catch the case where an item is
+                # created outside root and then renamed into root.
+                # Hence the walk for directories -- a tradeoff for ignoring "outside root" events.
+                log.debug("created in or renamed into root: %s", event.path)
+                if event.otype == DIRECTORY:
+                    return EventFilter.WALK
+            elif prior_subpath and not curr_subpath:
+                # Rename out of root: process the event.
+                # Treated as a delete by the sync engine, which handles non-empty folders by marking
+                # children "changed" and processing them first.
+                log.debug("renamed out of root: %s", event.path)
+            else:
+                # both curr and prior are subpaths == rename within root (process event)
+                # neither is subpath == rename outside root (ignore event)
+                return EventFilter.PROCESS if curr_subpath else EventFilter.IGNORE
+
+        return EventFilter.PROCESS
 
     def _prep_upload(self, path, metadata):
         # modification time

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,3 +1,52 @@
 """Imported test suite"""
+import io
 
 from cloudsync.tests import *
+
+
+def trash_oid(provider, oid):
+    gdrive_info = provider._prep_upload(None, {})
+    gdrive_info['trashed'] = True
+    fields = 'id, md5Checksum, trashed'
+
+    def api_call():
+        return provider._api('files', 'update',
+                         body=gdrive_info,
+                         fileId=oid,
+                         fields=fields)
+
+    if provider._client:
+        with patch.object(provider._client._http.http, "follow_redirects", False):  # pylint: disable=protected-access
+            res = api_call()
+    else:
+        res = api_call()
+
+    return res
+
+def test_trashed_files_folders(provider):
+    base = provider.temp_name("base_fold")
+    file_name1 = provider.join(base, provider.temp_name("file1.txt"))
+    file_name2 = provider.join(base, provider.temp_name("file2.txt"))
+    fold_name1 = provider.join(base, provider.temp_name("fold1"))
+    fold_name2 = provider.join(base, provider.temp_name("fold2"))
+
+    base_oid = provider.mkdir(base)
+    file1_oid = provider.create(file_name1, io.BytesIO(b"hello")).oid
+    file2_oid = provider.create(file_name2, io.BytesIO(b"world")).oid
+    fold1_oid = provider.mkdir(fold_name1)
+    fold2_oid = provider.mkdir(fold_name2)
+
+    trash_oid(provider, file1_oid)
+    trash_oid(provider, fold1_oid)
+
+    assert not provider.info_oid(file1_oid)
+    assert provider.info_oid(file2_oid)
+    assert not provider.info_oid(fold1_oid)
+    assert provider.info_oid(fold2_oid)
+
+    # Listdir should ignore trashed files
+    listdir_oids = [e.oid for e in list(provider.listdir(base_oid))]
+    assert not file1_oid in listdir_oids
+    assert file2_oid in listdir_oids
+    assert not fold1_oid in listdir_oids
+    assert fold2_oid in listdir_oids

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -2,9 +2,7 @@
 import io
 import datetime
 
-from cloudsync.sync.state import FILE, DIRECTORY
 from cloudsync.tests import *
-from cloudsync_gdrive import EventFilter as GDriveEventFilter
 
 SHARED_FOLDER_RESP = {'id': 'fake_oid', 'name': 'shared-fold', 'mimeType': 'application/vnd.google-apps.folder', 'trashed': False,
         'shared': True, 'capabilities': {'canEdit': True}}
@@ -98,44 +96,3 @@ def test_shared_folder_pids(provider):
     assert len(listdir_res) == 1
     assert provider._root_id in listdir_res[0].pids
     assert provider._root_id in info_oid_res.pids
-
-def test_event_filter(provider):
-    # root not set
-    assert not provider.root_path
-    event = Event(FILE, "", "", "", True)
-    assert provider._filter_event(event) == GDriveEventFilter.PROCESS
-    event = Event(DIRECTORY, "", "", "", False)
-    assert provider._filter_event(event) == GDriveEventFilter.PROCESS
-    assert provider._filter_event(None) == GDriveEventFilter.IGNORE
-
-    class MockSyncState:
-        def get_path(self, oid):
-            if oid == "in-root":
-                return "/root/path"
-            elif oid == "out-root":
-                return "/path"
-            else:
-                return None
-
-    # root set
-    with patch.multiple(provider.prov, _root_oid="root_oid", _root_path="/root", sync_state=MockSyncState()):
-        e = Event(FILE, "", "", "", False)
-        assert provider._filter_event(e) == GDriveEventFilter.IGNORE
-        e = Event(FILE, "in-root", "/root/path2", "hash", True)
-        assert provider._filter_event(e) == GDriveEventFilter.PROCESS
-        e = Event(FILE, "in-root", None, None, False)
-        assert provider._filter_event(e) == GDriveEventFilter.PROCESS
-        e = Event(FILE, "out-root", "/path2", "hash", True)
-        assert provider._filter_event(e) == GDriveEventFilter.IGNORE
-        e = Event(FILE, "out-root", None, None, False)
-        assert provider._filter_event(e) == GDriveEventFilter.IGNORE
-        e = Event(FILE, "in-root", "/path2", "hash", True)
-        assert provider._filter_event(e) == GDriveEventFilter.PROCESS
-        e = Event(FILE, "out-root", "/root/path2", "hash", True)
-        assert provider._filter_event(e) == GDriveEventFilter.PROCESS
-        e = Event(DIRECTORY, "out-root", "/root/path2", "hash", True)
-        assert provider._filter_event(e) == GDriveEventFilter.WALK
-
-        with pytest.raises(ValueError):
-            if provider._filter_event(e):
-                log.info("this should throw")


### PR DESCRIPTION
Mark exists as False only if they are removed. This PR also removes the additional api hit in the `events` function. This will leave `path` as `None` for the event and should wait to get populated by `get_latest` when syncing.

This is blocked by the corresponding cloudsync changes: https://github.com/AtakamaLLC/cloudsync/pull/329