### PR TITLE
BI2-1813: Fix arbitrary parent missing bug in shared files

### DIFF
--- a/cloudsync_gdrive.py
+++ b/cloudsync_gdrive.py
@@ -31,7 +31,7 @@ from cloudsync.oauth import OAuthConfig, OAuthError, OAuthProviderInfo
 CACHE_QUOTA_TIME = 120
 
 
-__version__ = "1.0.6"
+__version__ = "1.0.7"
 
 
 class GDriveFileDoneError(Exception):

--- a/cloudsync_gdrive.py
+++ b/cloudsync_gdrive.py
@@ -572,7 +572,7 @@ class GDriveProvider(Provider):  # pylint: disable=too-many-public-methods, too-
                 res = self._api('files', 'list',
                                 q=query,
                                 spaces='drive',
-                                fields='files(id, md5Checksum, parents, name, mimeType, trashed, shared, capabilities), nextPageToken',
+                                fields='files(id, md5Checksum, parents, name, mimeType, trashed, shared, headRevisionId, capabilities), nextPageToken',
                                 pageToken=page_token,
                                 includeItemsFromAllDrives=True,
                                 supportsAllDrives=True
@@ -696,7 +696,7 @@ class GDriveProvider(Provider):  # pylint: disable=too-many-public-methods, too-
             res = self._api('files', 'list',
                             q=query,
                             spaces='drive',
-                            fields='files(id, md5Checksum, parents, mimeType, trashed, name, shared, capabilities)',
+                            fields='files(id, md5Checksum, parents, mimeType, trashed, name, shared, headRevisionId, capabilities)',
                             pageToken=None,
                             includeItemsFromAllDrives=True,
                             supportsAllDrives=True)
@@ -823,7 +823,7 @@ class GDriveProvider(Provider):  # pylint: disable=too-many-public-methods, too-
     def _info_oid(self, oid) -> Optional[GDriveInfo]:
         try:
             res = self._api('files', 'get', fileId=oid, supportsAllDrives=True, 
-                            fields='name, md5Checksum, parents, mimeType, trashed, shared, capabilities, size')
+                            fields='name, md5Checksum, parents, mimeType, trashed, shared, headRevisionId, capabilities, size')
         except CloudFileNotFoundError:
             log.debug("info oid %s : not found", oid)
             if oid == self.__root_id:


### PR DESCRIPTION
Fixes a bug in gdrive where the parent field will be arbitrarily left out in the response for shared files existing in a subfolder. This PR adds the `headRevisionId` field to the request which is a fix mentioned in the GDrive issue tracker https://issuetracker.google.com/issues/62671922 for this bug.